### PR TITLE
Add check before defining custom v-slot element

### DIFF
--- a/src/vampire-slot.ts
+++ b/src/vampire-slot.ts
@@ -138,4 +138,6 @@ declare global {
   }
 }
 
-customElements.define(VampireSlot.tagName, VampireSlot);
+if (!customElements.get(VampireSlot.tagName)) {
+  customElements.define(VampireSlot.tagName, VampireSlot);
+}


### PR DESCRIPTION
This prevents errors when multiple vampire-slot components from different libraries land on the same page at the same time.

@daniel-nagy I can't get any of the tests to pass on a fresh clone, but this is a pretty common pattern I've seen when defining custom elements. Thoughts on including this?